### PR TITLE
Add CanTouch Warning

### DIFF
--- a/src/Input/VRHandInteract.lua
+++ b/src/Input/VRHandInteract.lua
@@ -28,6 +28,9 @@ end)
 Creates a VR Hand Input.
 --]]
 function VRHandInteract.new(Input: Unified3DInputTypes.Unified3DInput): Unified3DInputTypes.Input
+    if not Input.Part.CanTouch then
+        warn(`{Input.Part:GetFullName()} has VRHandInteract set up but CanTouch is false. VR inputs will not work for this part.`)
+    end
     return setmetatable({
         Input = Input,
         Enabled = false,

--- a/src/Unified3DInputTypes.lua
+++ b/src/Unified3DInputTypes.lua
@@ -11,6 +11,7 @@ export type Input = {
     Destroy: (Input) -> (),
 }
 export type Unified3DInput = {
+    Part: BasePart,
     SetMaxActivationDistance: (Unified3DInput, number) -> Unified3DInput,
     AddInput: (Unified3DInput, string, {[string]: any}?) -> Unified3DInput,
     Enable: (Unified3DInput) -> (),


### PR DESCRIPTION
`VRHandInteract` can silently not work when `CanTouch` is `false`. A simple warning for the part having `CanTouch` as `false` can help mitigate this.