### PR TITLE
Update ProximityPrompt.luau

### DIFF
--- a/src/Input/ProximityPrompt.luau
+++ b/src/Input/ProximityPrompt.luau
@@ -63,8 +63,8 @@ function ProximityPrompt.UpdateOffset(self: ProximityPromptInput): ()
         local ProximityPromptAttachment = Instance.new("Attachment")
         ProximityPromptAttachment.Name = HttpService:GenerateGUID()
         ProximityPromptAttachment.Parent = self.Input.Part
-        ProximityPrompt.Parent = self.ProximityPromptAttachment
         self.ProximityPromptAttachment = ProximityPromptAttachment
+        self.ProximityPrompt.Parent = self.ProximityPromptAttachment
     end
     (self.ProximityPromptAttachment :: Attachment).Position = self.Properties["Offset"]
 end


### PR DESCRIPTION
Fixed ProximityPrompt not being parented under the offset attachment properly. Previously, the UpdateOffset function tried to set ProximityPrompt module's Parent value of the actual instance parent. The function also previously tried to use self.ProximityPromptAttachment before it was initialized.